### PR TITLE
ajout github de la pres d'alegrand

### DIFF
--- a/docs/presentations.html
+++ b/docs/presentations.html
@@ -13,7 +13,7 @@
 
 <title>Les présentations et ateliers</title>
 
-<script src="site_libs/header-attrs-2.9/header-attrs.js"></script>
+<script src="site_libs/header-attrs-2.8/header-attrs.js"></script>
 <script src="site_libs/jquery-1.11.3/jquery.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/bootstrap.min.css" rel="stylesheet" />
@@ -248,35 +248,35 @@ $(document).ready(function () {
 </li>
 <li>
   <a href="programme.html">
-    <span class="fa fa-calendar-alt"></span>
+    <span class="fas fa-calendar-alt"></span>
      
     Programme
   </a>
 </li>
 <li>
   <a href="installations.html">
-    <span class="fa fa-cog"></span>
+    <span class="fas fa-cog"></span>
      
     Installation
   </a>
 </li>
 <li>
   <a href="presentations.html">
-    <span class="fa fa-window-restore"></span>
+    <span class="fas fa-window-restore"></span>
      
     Présentations
   </a>
 </li>
 <li>
   <a href="exposes.html">
-    <span class="fa fa-user-friends"></span>
+    <span class="fas fa-user-friends"></span>
      
     Exposés
   </a>
 </li>
 <li>
   <a href="pad.html">
-    <span class="fa fa-file-alt"></span>
+    <span class="fas fa-file-alt"></span>
      
     Pad
   </a>
@@ -288,7 +288,7 @@ $(document).ready(function () {
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/sigr2021/site">
-    <span class="fa fa-github"></span>
+    <span class="fas fa-github"></span>
      
   </a>
 </li>
@@ -312,7 +312,7 @@ $(document).ready(function () {
 <h2>Outils de la recherche reproductible</h2>
 <div id="reproducibility-crisis-and-open-science" class="section level3">
 <h3><i class="fas fa-window-restore"></i> <a href="https://raw.githubusercontent.com/alegrand/SMPE/master/lectures/talk_21_06_28_Oleron.pdf">Reproducibility Crisis and Open Science</a></h3>
-<p><i class="fas fa-user"></i> <a href="https://team.inria.fr/polaris/members/arnaud-legrand/">Arnaud Legrand (UMR LIG - CNRS)</a> </br></br></p>
+<p><i class="fas fa-user"></i> <a href="https://team.inria.fr/polaris/members/arnaud-legrand/">Arnaud Legrand (UMR LIG - CNRS)</a> <a href="https://github.com/alegrand/SMPE/blob/master/lectures/talk_21_06_28_Oleron.org"> <i class="fab fa-github"></i></a> </br></br></p>
 </div>
 <div id="introduction-à-markdown-pour-r" class="section level3">
 <h3><i class="fas fa-wrench"></i> <a href="https://sigr2021.github.io/markdown">Introduction à Markdown pour R</a></h3>

--- a/presentations.Rmd
+++ b/presentations.Rmd
@@ -7,7 +7,7 @@ title: "Les présentations et ateliers"
 ## Outils de la recherche reproductible
 
 ### <i class="fas fa-window-restore"></i> [Reproducibility Crisis and Open Science](https://raw.githubusercontent.com/alegrand/SMPE/master/lectures/talk_21_06_28_Oleron.pdf)    
-<i class="fas fa-user"></i> <a href="https://team.inria.fr/polaris/members/arnaud-legrand/">Arnaud Legrand (UMR LIG - CNRS)</a>
+<i class="fas fa-user"></i> <a href="https://team.inria.fr/polaris/members/arnaud-legrand/">Arnaud Legrand (UMR LIG - CNRS)</a> <a href="https://github.com/alegrand/SMPE/blob/master/lectures/talk_21_06_28_Oleron.org"> <i class="fab fa-github"></i></a>
 </br></br>
 
 ### <i class="fas fa-wrench"></i> [Introduction à Markdown pour R](https://sigr2021.github.io/markdown)  


### PR DESCRIPTION
Hello, 

J'ai juste ajouté le lien vers le github d'alegrand où est la source de sa presentation, comme je l'ai cherché pour des sources. Par contre il y a une difference dans la version de header (2.8 et 2.9). Je ne sais pas comment la changer (il faut que je crochete tout le site ?). 

Je peux resoumettre jsute le .Rmd sans crocheter l'html au besoin.

++